### PR TITLE
Fixed Attribute Error in Get Cell Value Keyword

### DIFF
--- a/SapGuiLibrary/SapGuiLibrary.py
+++ b/SapGuiLibrary/SapGuiLibrary.py
@@ -286,7 +286,7 @@ class SapGuiLibrary:
         self.element_should_be_present(table_id)
 
         try:
-            cellValue = self.session.findById(table_id).getCellValue(row_num, col_id)
+            cellValue = self.session.findById(table_id).getCell(row_num, col_id).text
             return cellValue
         except com_error:
             self.take_screenshot()


### PR DESCRIPTION
The Keyword `Get Cell Value` contains a wrong method call to "getCellValue", which does not exist.
This should fix issue #9 .